### PR TITLE
fix: don't use preact internal vnode

### DIFF
--- a/src/ChildrenUtils.ts
+++ b/src/ChildrenUtils.ts
@@ -109,10 +109,8 @@ export function mergeChildren(prev, next) {
     return ret;
 }
 
-const VNode = h("a", null).constructor;
-
 export function isValidElement(element) {
-    return element && (element instanceof VNode);
+    return element && element.hasOwnProperty('nodeName');
 }
 
 export function isChildrenShow(child, children, showProp, key, flag = false) {


### PR DESCRIPTION
Webpack 4 (with uglify-es) will inline the VNode definition into preact.h which causes the instanceof check to fail, instead we can check if the object has a nodeName as this is guaranteed by preact.h